### PR TITLE
Clear local aggregate cache when Hazelcast membership changes to avoid split brain

### DIFF
--- a/src/main/java/engineering/everest/starterkit/axon/config/AxonHazelcastConfig.java
+++ b/src/main/java/engineering/everest/starterkit/axon/config/AxonHazelcastConfig.java
@@ -10,8 +10,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.cache.Cache;
-import javax.cache.CacheManager;
 import javax.cache.configuration.MutableConfiguration;
 import javax.cache.expiry.CreatedExpiryPolicy;
 import java.util.List;
@@ -22,9 +20,8 @@ import static javax.cache.expiry.Duration.FIVE_MINUTES;
 @Configuration
 @Log4j2
 public class AxonHazelcastConfig {
-
     public static final String AXON_COMMAND_DISPATCHER = "axon-command-dispatcher";
-    private static final String AXON_AGGREGATES_CACHE = "axonAggregates";
+    public static final String AXON_AGGREGATES_CACHE = "axonAggregates";
 
     private List<HazelcastConfigurationStrategy> configurationStrategies;
 

--- a/src/main/java/engineering/everest/starterkit/axon/config/HazelcastMembershipChangeCacheInvalidator.java
+++ b/src/main/java/engineering/everest/starterkit/axon/config/HazelcastMembershipChangeCacheInvalidator.java
@@ -1,0 +1,38 @@
+package engineering.everest.starterkit.axon.config;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.core.MembershipListener;
+import org.ehcache.jsr107.EhcacheCachingProvider;
+import org.springframework.stereotype.Component;
+
+import static engineering.everest.starterkit.axon.config.AxonHazelcastConfig.AXON_AGGREGATES_CACHE;
+import static javax.cache.Caching.getCachingProvider;
+
+@Component
+public class HazelcastMembershipChangeCacheInvalidator implements MembershipListener {
+
+    public HazelcastMembershipChangeCacheInvalidator(HazelcastInstance hazelcastInstance) {
+        hazelcastInstance.getCluster().addMembershipListener(this);
+    }
+
+    @Override
+    public void memberAdded(MembershipEvent membershipEvent) {
+        clearLocalAxonCache();
+    }
+
+    @Override
+    public void memberRemoved(MembershipEvent membershipEvent) {
+        clearLocalAxonCache();
+    }
+
+    @Override
+    public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+    }
+
+    private void clearLocalAxonCache() {
+        var cacheManager = getCachingProvider(EhcacheCachingProvider.class.getCanonicalName()).getCacheManager();
+        cacheManager.getCache(AXON_AGGREGATES_CACHE).clear();
+    }
+}

--- a/src/test/java/engineering/everest/starterkit/axon/config/HazelcastMembershipChangeCacheInvalidatorTest.java
+++ b/src/test/java/engineering/everest/starterkit/axon/config/HazelcastMembershipChangeCacheInvalidatorTest.java
@@ -1,0 +1,74 @@
+package engineering.everest.starterkit.axon.config;
+
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MembershipEvent;
+import org.ehcache.jsr107.EhcacheCachingProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.cache.CacheManager;
+import javax.cache.configuration.MutableConfiguration;
+
+import static engineering.everest.starterkit.axon.config.AxonHazelcastConfig.AXON_AGGREGATES_CACHE;
+import static java.util.UUID.randomUUID;
+import static javax.cache.Caching.getCachingProvider;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HazelcastMembershipChangeCacheInvalidatorTest {
+
+    private HazelcastMembershipChangeCacheInvalidator hazelcastMembershipChangeCacheInvalidator;
+
+    @Mock
+    private HazelcastInstance hazelcastInstance;
+    @Mock
+    private Cluster cluster;
+
+    @BeforeEach
+    void setUp() {
+        getCacheManager().createCache(AXON_AGGREGATES_CACHE, new MutableConfiguration<>());
+        when(hazelcastInstance.getCluster()).thenReturn(cluster);
+
+        hazelcastMembershipChangeCacheInvalidator = new HazelcastMembershipChangeCacheInvalidator(hazelcastInstance);
+    }
+
+    @AfterEach
+    void tearDown() {
+        getCacheManager().destroyCache(AXON_AGGREGATES_CACHE);
+    }
+
+    @Test
+    void registersItselfAsAHazelcastClusterMembershipListener() {
+        verify(cluster).addMembershipListener(hazelcastMembershipChangeCacheInvalidator);
+    }
+
+    @Test
+    void axonCacheIsCleared_WhenClusterMemberAdded() {
+        getCacheManager().getCache(AXON_AGGREGATES_CACHE).put(randomUUID(), "a cached object");
+
+        hazelcastMembershipChangeCacheInvalidator.memberAdded(mock(MembershipEvent.class));
+
+        assertFalse(getCacheManager().getCache(AXON_AGGREGATES_CACHE).iterator().hasNext());
+    }
+
+    @Test
+    void axonCacheIsCleared_WhenClusterMemberRemoved() {
+        getCacheManager().getCache(AXON_AGGREGATES_CACHE).put(randomUUID(), "a cached object");
+
+        hazelcastMembershipChangeCacheInvalidator.memberRemoved(mock(MembershipEvent.class));
+
+        assertFalse(getCacheManager().getCache(AXON_AGGREGATES_CACHE).iterator().hasNext());
+    }
+
+    private CacheManager getCacheManager() {
+        return getCachingProvider(EhcacheCachingProvider.class.getCanonicalName()).getCacheManager();
+    }
+}


### PR DESCRIPTION
Closes #5 